### PR TITLE
Remove duplicate results of the same test case

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   timeout: 10 * 1000,
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: 0,
+  retries: 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/tests/modules/reporter.test.ts
+++ b/tests/modules/reporter.test.ts
@@ -23,6 +23,7 @@ test("レポートが正しく出力されること", () => {
       "playwright.test.ts:10:6",
     ]),
   );
+  expect(skipped.length).toEqual(6);
   const expected = (report as Report).results
     .filter((r: Result) => r.outcome === "expected")
     .map((r: Result) => r.location);
@@ -36,6 +37,7 @@ test("レポートが正しく出力されること", () => {
       "playwright.test.ts:3:5",
     ]),
   );
+  expect(expected.length).toEqual(6);
   const unexpected = (report as Report).results
     .filter((r: Result) => r.outcome === "unexpected")
     .map((r: Result) => r.location);
@@ -55,6 +57,7 @@ test("レポートが正しく出力されること", () => {
       "playwright.test.ts:24:5",
     ]),
   );
+  expect(unexpected.length).toEqual(12);
   const flaky = (report as Report).results
     .filter((r: Result) => r.outcome === "flaky")
     .map((r: Result) => r.location);


### PR DESCRIPTION
### Changes

- Remove duplicate results of the same test case due to [retries the test](https://playwright.dev/docs/test-retries).